### PR TITLE
feat(hardening): complete enterprise follow-ups

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -62,6 +62,14 @@ Expected behavior:
   - Valid names currently include `ci_smoke`, `pr_gate`, `nightly_truth`.
 - `--results-dir <path>`: custom artifact root (default is `benchmark/results`).
 - `--no-save-results`: run benchmark without persisting artifacts.
+- `--sections <csv>`: run only selected benchmark sections (comma-separated).
+  - Valid section names: `sync_logger`, `network_destination`, `async_logger`,
+    `composite_logger`, `composite_async_logger`, `configurations`, `output_matrix`,
+    `file_writing`, `async_file_writing`, `memory`, `concurrent`, `async_concurrent`,
+    `parallel_workers`, `advanced_concurrent`, `ultra_high_performance`.
+  - Precedence is `--sections` (CLI) over profile `enabled_sections`.
+  - Partial section runs automatically disable result persistence unless you already
+    set `--no-save-results`, preserving full-suite artifact contract expectations.
 
 Examples:
 
@@ -74,6 +82,9 @@ python3 benchmark/performance_benchmark.py --profile pr_gate --results-dir bench
 
 # Run without artifact persistence
 python3 benchmark/performance_benchmark.py --profile ci_smoke --no-save-results
+
+# Run only a local diagnostic slice
+python3 benchmark/performance_benchmark.py --profile pr_gate --sections sync_logger,memory
 ```
 
 Report verbosity environment variable:

--- a/benchmark/performance_benchmark.py
+++ b/benchmark/performance_benchmark.py
@@ -27,7 +27,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 import platform
-from typing import Any, Dict, List, Literal, Tuple, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, cast
 
 # Add the project root to Python path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -94,6 +94,7 @@ class HydraLoggerBenchmark:  # pragma: no cover
         save_results: bool = True,
         results_dir: str | None = None,
         profile: str | None = None,
+        enabled_sections: List[str] | None = None,
     ):
         self.results = {}
         self.save_results = save_results
@@ -194,6 +195,112 @@ class HydraLoggerBenchmark:  # pragma: no cover
             if isinstance(repetition_sections, list)
             else []
         )
+        profile_enabled_sections = self.profile.get("enabled_sections", [])
+        self.enabled_sections = self._resolve_enabled_sections(
+            cli_sections=enabled_sections,
+            profile_sections=profile_enabled_sections,
+        )
+        self._is_partial_section_run = len(self.enabled_sections) < len(
+            self._all_section_names()
+        )
+        if self._is_partial_section_run and self.save_results:
+            print(
+                "Partial section benchmark requested; disabling result artifact persistence "
+                "to preserve full-suite benchmark schema contracts."
+            )
+            self.save_results = False
+
+    def _section_plan(
+        self,
+    ) -> List[Tuple[str, Literal["sync", "async"], Any, Optional[int]]]:
+        """Ordered benchmark section execution plan."""
+        return [
+            ("sync_logger", "sync", self.test_sync_logger_performance, None),
+            (
+                "network_destination",
+                "sync",
+                self.test_network_destination_performance,
+                1,
+            ),
+            ("async_logger", "async", self.test_async_logger_performance, None),
+            ("composite_logger", "sync", self.test_composite_logger_performance, None),
+            (
+                "composite_async_logger",
+                "async",
+                self.test_composite_async_logger_performance,
+                None,
+            ),
+            ("configurations", "sync", self.test_configuration_performance, 1),
+            ("output_matrix", "async", self.test_output_matrix_performance, 1),
+            ("file_writing", "sync", self.test_file_writing_performance, None),
+            (
+                "async_file_writing",
+                "async",
+                self.test_async_file_writing_performance,
+                None,
+            ),
+            ("memory", "sync", self.test_memory_usage, 1),
+            ("concurrent", "async", self.test_concurrent_logging, None),
+            ("async_concurrent", "async", self.test_async_concurrent_suite, None),
+            ("parallel_workers", "sync", self.test_parallel_workers_suite, None),
+            (
+                "advanced_concurrent",
+                "async",
+                self.test_advanced_concurrent_logging,
+                None,
+            ),
+            (
+                "ultra_high_performance",
+                "async",
+                self.test_ultra_high_performance,
+                None,
+            ),
+        ]
+
+    def _all_section_names(self) -> List[str]:
+        """Return all supported benchmark section names in execution order."""
+        return [name for name, _kind, _scenario, _repeat in self._section_plan()]
+
+    @staticmethod
+    def _normalize_sections(raw: Any) -> List[str]:
+        """Normalize section config/CLI payloads into ordered unique names."""
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            items = [item.strip() for item in raw.split(",")]
+        elif isinstance(raw, list):
+            items = [str(item).strip() for item in raw]
+        else:
+            raise ValueError("enabled_sections must be a list of section names or CSV string")
+
+        normalized: List[str] = []
+        for item in items:
+            if not item:
+                continue
+            if item not in normalized:
+                normalized.append(item)
+        return normalized
+
+    def _resolve_enabled_sections(
+        self, cli_sections: Any, profile_sections: Any
+    ) -> List[str]:
+        """Resolve active sections with precedence CLI > profile > full suite."""
+        supported = self._all_section_names()
+        selected = self._normalize_sections(cli_sections) or self._normalize_sections(
+            profile_sections
+        )
+        if not selected:
+            return supported
+
+        unknown = [name for name in selected if name not in supported]
+        if unknown:
+            raise ValueError(
+                "Unknown benchmark section(s): "
+                + ", ".join(unknown)
+                + ". Supported sections: "
+                + ", ".join(supported)
+            )
+        return selected
 
     def _build_benchmark_log_path(self, prefix: str) -> str:
         """Create a unique benchmark log path under benchmark_logs."""
@@ -3297,74 +3404,24 @@ class HydraLoggerBenchmark:  # pragma: no cover
     async def run_benchmark(self):
         """Run the complete benchmark suite."""
         self.print_header()
+        print(f"Active sections: {', '.join(self.enabled_sections)}")
 
         try:
-            # Run all performance tests
-            # Cleanup between tests ensures each test starts with a clean state
-            self.results["sync_logger"] = self._run_repeated_sync(
-                section="sync_logger",
-                scenario=self.test_sync_logger_performance,
-            )
-            self.results["network_destination"] = self._run_repeated_sync(
-                section="network_destination",
-                scenario=self.test_network_destination_performance,
-                repeat=1,
-            )
-            self.results["async_logger"] = await self._run_repeated_async(
-                section="async_logger",
-                scenario=self.test_async_logger_performance,
-            )
-            self.results["composite_logger"] = self._run_repeated_sync(
-                section="composite_logger",
-                scenario=self.test_composite_logger_performance,
-            )
-            self.results["composite_async_logger"] = await self._run_repeated_async(
-                section="composite_async_logger",
-                scenario=self.test_composite_async_logger_performance,
-            )
-            self.results["configurations"] = self._run_repeated_sync(
-                section="configurations",
-                scenario=self.test_configuration_performance,
-                repeat=1,
-            )
-            self.results["output_matrix"] = await self._run_repeated_async(
-                section="output_matrix",
-                scenario=self.test_output_matrix_performance,
-                repeat=1,
-            )
-            self.results["file_writing"] = self._run_repeated_sync(
-                section="file_writing",
-                scenario=self.test_file_writing_performance,
-            )
-            self.results["async_file_writing"] = await self._run_repeated_async(
-                section="async_file_writing",
-                scenario=self.test_async_file_writing_performance,
-            )
-            self.results["memory"] = self._run_repeated_sync(
-                section="memory",
-                scenario=self.test_memory_usage,
-                repeat=1,
-            )
-            self.results["concurrent"] = await self._run_repeated_async(
-                section="concurrent",
-                scenario=self.test_concurrent_logging,
-            )
-            self.results["async_concurrent"] = await self._run_repeated_async(
-                section="async_concurrent",
-                scenario=self.test_async_concurrent_suite,
-            )
-            self.results["parallel_workers"] = self._run_repeated_sync(
-                section="parallel_workers",
-                scenario=self.test_parallel_workers_suite,
-            )
-            self.results["advanced_concurrent"] = await self._run_repeated_async(
-                section="advanced_concurrent",
-                scenario=self.test_advanced_concurrent_logging,
-            )
-            self.results["ultra_high_performance"] = await self._run_repeated_async(
-                section="ultra_high_performance",
-                scenario=self.test_ultra_high_performance,
-            )
+            for section_name, section_kind, scenario, repeat in self._section_plan():
+                if section_name not in self.enabled_sections:
+                    continue
+                if section_kind == "sync":
+                    self.results[section_name] = self._run_repeated_sync(
+                        section=section_name,
+                        scenario=scenario,
+                        repeat=repeat,
+                    )
+                else:
+                    self.results[section_name] = await self._run_repeated_async(
+                        section=section_name,
+                        scenario=scenario,
+                        repeat=repeat,
+                    )
 
             # Enforce hard reliability rules before reporting/saving artifacts.
             self._enforce_reliability_guards()
@@ -3400,12 +3457,14 @@ async def main(
     profile: str | None = None,
     save_results: bool = True,
     results_dir: str | None = None,
+    enabled_sections: List[str] | None = None,
 ):
     """Main entry point for the benchmark suite."""
     benchmark = HydraLoggerBenchmark(
         save_results=save_results,
         results_dir=results_dir,
         profile=profile,
+        enabled_sections=enabled_sections,
     )
     return await benchmark.run_benchmark()
 
@@ -3428,12 +3487,24 @@ if __name__ == "__main__":  # pragma: no cover
         default=None,
         help="Custom directory for benchmark result artifacts.",
     )
+    parser.add_argument(
+        "--sections",
+        default=None,
+        help=(
+            "Comma-separated benchmark section names to run. "
+            "Overrides profile enabled_sections."
+        ),
+    )
     args = parser.parse_args()
+    section_list = (
+        [item.strip() for item in args.sections.split(",")] if args.sections else None
+    )
     exit_code = asyncio.run(
         main(
             profile=args.profile,
             save_results=not args.no_save_results,
             results_dir=args.results_dir,
+            enabled_sections=section_list,
         )
     )
     sys.exit(exit_code)

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -44,6 +44,9 @@ Primary references:
 .hydra_env/bin/python benchmark/performance_benchmark.py --profile ci_smoke
 .hydra_env/bin/python benchmark/performance_benchmark.py --profile pr_gate
 .hydra_env/bin/python benchmark/performance_benchmark.py --profile nightly_truth
+
+# Targeted local/CI slice (comma-separated benchmark sections)
+.hydra_env/bin/python benchmark/performance_benchmark.py --profile pr_gate --sections sync_logger,memory
 ```
 
 Use profile-specific artifact roots for cleaner comparison history:
@@ -53,6 +56,13 @@ Use profile-specific artifact roots for cleaner comparison history:
 .hydra_env/bin/python benchmark/performance_benchmark.py --profile pr_gate --results-dir benchmark/results/pr_gate
 .hydra_env/bin/python benchmark/performance_benchmark.py --profile nightly_truth --results-dir benchmark/results/nightly_truth
 ```
+
+Section filtering notes:
+
+- Profile config may define `enabled_sections`.
+- CLI `--sections` overrides profile `enabled_sections`.
+- Partial section runs are treated as diagnostic slices and do not persist artifacts by
+  default, so timestamped full-suite benchmark history remains schema-compatible.
 
 ---
 

--- a/hydra_logger/loggers/async_logger.py
+++ b/hydra_logger/loggers/async_logger.py
@@ -85,6 +85,7 @@ class AsyncLogger(BaseLogger):
 
         # Feature components
         self._plugin_manager = None
+        self._extension_manager = None
 
         # Feature flags - DISABLED by default for performance
         self._enable_security = False
@@ -154,14 +155,15 @@ class AsyncLogger(BaseLogger):
     def _setup_data_protection(self):
         """Setup simple data protection features."""
         self._data_protection = None
-        if not self._enable_data_protection:
-            return
-
         mgr = (
             getattr(self._config, "_extension_manager", None)
             if self._config is not None
             else None
         )
+        self._extension_manager = mgr
+        if not self._enable_data_protection:
+            return
+
         if mgr is not None:
             from ..extensions.extension_base import SecurityExtension
 
@@ -652,6 +654,11 @@ class AsyncLogger(BaseLogger):
             record = self._extension_processor.apply_data_protection(
                 record, self._data_protection
             )
+            record = self._extension_processor.apply_non_data_protection_extensions(
+                record,
+                self._extension_manager,
+                self._data_protection,
+            )
 
             layer_name = getattr(record, "layer", "default")
             handlers = self._get_handlers_for_layer(layer_name)
@@ -714,6 +721,11 @@ class AsyncLogger(BaseLogger):
             record = self._record_builder.create(level, message, **kwargs)
             record = self._extension_processor.apply_data_protection(
                 record, self._data_protection
+            )
+            record = self._extension_processor.apply_non_data_protection_extensions(
+                record,
+                self._extension_manager,
+                self._data_protection,
             )
 
             await self._emit_to_handlers(record)

--- a/hydra_logger/loggers/pipeline/extension_processor.py
+++ b/hydra_logger/loggers/pipeline/extension_processor.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any, Optional
 
 from ...core.exceptions import HydraLoggerError
+from ...extensions.extension_base import SecurityExtension
 from ...types.records import LogRecord
 
 _logger = logging.getLogger(__name__)
@@ -48,5 +49,48 @@ class ExtensionProcessor:
                     _logger.exception(
                         "Data protection extension failed for type=%s",
                         type(data_protection).__name__,
+                    )
+        return record
+
+    def apply_non_data_protection_extensions(
+        self,
+        record: LogRecord,
+        extension_manager: Optional[Any],
+        data_protection_extension: Optional[Any],
+    ) -> LogRecord:
+        """Apply enabled non-security extensions in configured manager order."""
+        if extension_manager is None:
+            return record
+
+        processing_order = extension_manager.get_processing_order()
+        for extension_name in processing_order:
+            extension = extension_manager.get_extension(extension_name)
+            if extension is None or not extension.is_enabled():
+                continue
+            if extension is data_protection_extension:
+                continue
+            if isinstance(extension, SecurityExtension):
+                continue
+            try:
+                record.message = extension.process(record.message)
+                if record.context:
+                    record.context = extension.process(record.context)
+                if record.extra:
+                    record.extra = extension.process(record.extra)
+            except Exception as error:
+                if self._owner is not None and hasattr(
+                    self._owner, "_handle_internal_failure"
+                ):
+                    try:
+                        self._owner._handle_internal_failure(
+                            f"extension_{extension_name}", error
+                        )
+                    except HydraLoggerError:
+                        raise
+                else:
+                    _logger.exception(
+                        "Extension processing failed for extension=%s type=%s",
+                        extension_name,
+                        type(extension).__name__,
                     )
         return record

--- a/hydra_logger/loggers/sync_logger.py
+++ b/hydra_logger/loggers/sync_logger.py
@@ -94,6 +94,7 @@ class SyncLogger(BaseLogger):
         self._data_sanitizer = None
         self._fallback_handler = None
         self._plugin_manager = None
+        self._extension_manager = None
 
         # Feature flags - DISABLED by default for performance
         self._enable_security = False
@@ -226,14 +227,15 @@ class SyncLogger(BaseLogger):
     def _setup_data_protection(self):
         """Setup simple data protection features."""
         self._data_protection = None
-        if not self._enable_data_protection:
-            return
-
         mgr = (
             getattr(self._config, "_extension_manager", None)
             if self._config is not None
             else None
         )
+        self._extension_manager = mgr
+        if not self._enable_data_protection:
+            return
+
         if mgr is not None:
             from ..extensions.extension_base import SecurityExtension
 
@@ -525,6 +527,11 @@ class SyncLogger(BaseLogger):
             record = self._record_builder.create(level, message, **kwargs)
             record = self._extension_processor.apply_data_protection(
                 record, self._data_protection
+            )
+            record = self._extension_processor.apply_non_data_protection_extensions(
+                record,
+                self._extension_manager,
+                self._data_protection,
             )
 
             layer_name = kwargs.get("layer", "default")

--- a/tests/benchmark/test_benchmark_profiles_slice_c.py
+++ b/tests/benchmark/test_benchmark_profiles_slice_c.py
@@ -55,3 +55,38 @@ def test_benchmark_init_applies_profile_overrides(tmp_path) -> None:
     assert bench.strict_reliability_guards is False
     assert bench.write_markdown_reports is False
     assert bench.output_matrix_overrides["include_extensions"] is False
+
+
+def test_benchmark_profile_enabled_sections_applied_when_cli_absent(
+    tmp_path, monkeypatch
+) -> None:
+    def fake_profile(_name):  # type: ignore[no-untyped-def]
+        return {
+            "enabled_sections": ["sync_logger", "memory"],
+            "test_config_overrides": {},
+        }
+
+    monkeypatch.setattr("benchmark.performance_benchmark.load_profile", fake_profile)
+    bench = HydraLoggerBenchmark(
+        save_results=False,
+        results_dir=str(tmp_path / "results"),
+        profile="custom",
+    )
+    assert bench.enabled_sections == ["sync_logger", "memory"]
+
+
+def test_benchmark_cli_sections_override_profile_sections(tmp_path, monkeypatch) -> None:
+    def fake_profile(_name):  # type: ignore[no-untyped-def]
+        return {
+            "enabled_sections": ["sync_logger", "memory"],
+            "test_config_overrides": {},
+        }
+
+    monkeypatch.setattr("benchmark.performance_benchmark.load_profile", fake_profile)
+    bench = HydraLoggerBenchmark(
+        save_results=False,
+        results_dir=str(tmp_path / "results"),
+        profile="custom",
+        enabled_sections=["async_logger"],
+    )
+    assert bench.enabled_sections == ["async_logger"]

--- a/tests/benchmark/test_benchmark_profiles_slice_c.py
+++ b/tests/benchmark/test_benchmark_profiles_slice_c.py
@@ -75,7 +75,9 @@ def test_benchmark_profile_enabled_sections_applied_when_cli_absent(
     assert bench.enabled_sections == ["sync_logger", "memory"]
 
 
-def test_benchmark_cli_sections_override_profile_sections(tmp_path, monkeypatch) -> None:
+def test_benchmark_cli_sections_override_profile_sections(
+    tmp_path, monkeypatch
+) -> None:
     def fake_profile(_name):  # type: ignore[no-untyped-def]
         return {
             "enabled_sections": ["sync_logger", "memory"],

--- a/tests/benchmark/test_performance_benchmark.py
+++ b/tests/benchmark/test_performance_benchmark.py
@@ -352,7 +352,8 @@ def test_main_forwards_enabled_sections(monkeypatch) -> None:
 
     monkeypatch.setattr(perf_mod, "HydraLoggerBenchmark", DummyBenchmark)
     assert (
-        asyncio.run(perf_mod.main(enabled_sections=["sync_logger", "async_logger"])) == 0
+        asyncio.run(perf_mod.main(enabled_sections=["sync_logger", "async_logger"]))
+        == 0
     )
     assert seen["enabled_sections"] == ["sync_logger", "async_logger"]
 

--- a/tests/benchmark/test_performance_benchmark.py
+++ b/tests/benchmark/test_performance_benchmark.py
@@ -315,16 +315,46 @@ def test_run_benchmark_returns_error_and_still_cleans_up(tmp_path, monkeypatch) 
 
 def test_main_returns_run_benchmark_code(monkeypatch) -> None:
     class DummyBenchmark:
-        def __init__(self, save_results=True, results_dir=None, profile=None):
+        def __init__(
+            self,
+            save_results=True,
+            results_dir=None,
+            profile=None,
+            enabled_sections=None,
+        ):
             assert save_results is True
             assert results_dir is None
             assert profile is None
+            assert enabled_sections is None
 
         async def run_benchmark(self):
             return 7
 
     monkeypatch.setattr(perf_mod, "HydraLoggerBenchmark", DummyBenchmark)
     assert asyncio.run(perf_mod.main()) == 7
+
+
+def test_main_forwards_enabled_sections(monkeypatch) -> None:
+    seen = {}
+
+    class DummyBenchmark:
+        def __init__(
+            self,
+            save_results=True,
+            results_dir=None,
+            profile=None,
+            enabled_sections=None,
+        ):
+            seen["enabled_sections"] = enabled_sections
+
+        async def run_benchmark(self):
+            return 0
+
+    monkeypatch.setattr(perf_mod, "HydraLoggerBenchmark", DummyBenchmark)
+    assert (
+        asyncio.run(perf_mod.main(enabled_sections=["sync_logger", "async_logger"])) == 0
+    )
+    assert seen["enabled_sections"] == ["sync_logger", "async_logger"]
 
 
 def test_network_destination_performance_uses_stubbed_http_handler(tmp_path) -> None:
@@ -338,3 +368,66 @@ def test_network_destination_performance_uses_stubbed_http_handler(tmp_path) -> 
     assert result["total_messages"] == 5
     assert result["dispatched_messages"] == 5
     assert result["individual_messages_per_second"] > 0
+
+
+def test_init_rejects_unknown_enabled_sections(tmp_path) -> None:
+    try:
+        HydraLoggerBenchmark(
+            save_results=False,
+            results_dir=str(tmp_path / "results"),
+            enabled_sections=["unknown_section"],
+        )
+    except ValueError as exc:
+        assert "Unknown benchmark section(s)" in str(exc)
+    else:
+        raise AssertionError("Expected unknown section validation error")
+
+
+def test_run_benchmark_honors_enabled_sections_subset(tmp_path, monkeypatch) -> None:
+    bench = HydraLoggerBenchmark(
+        save_results=True,
+        results_dir=str(tmp_path / "results"),
+        enabled_sections=["sync_logger", "memory"],
+    )
+    assert bench.save_results is False
+    order = []
+
+    monkeypatch.setattr(bench, "print_header", lambda: order.append("header"))
+    monkeypatch.setattr(
+        bench,
+        "test_sync_logger_performance",
+        lambda: order.append("sync") or {"ok": True},
+    )
+    monkeypatch.setattr(
+        bench,
+        "test_memory_usage",
+        lambda: order.append("memory") or {"ok": True},
+    )
+    monkeypatch.setattr(
+        bench,
+        "_enforce_reliability_guards",
+        lambda: order.append("guards"),
+    )
+    monkeypatch.setattr(
+        bench,
+        "print_detailed_results",
+        lambda: order.append("details"),
+    )
+    monkeypatch.setattr(
+        bench,
+        "save_results_to_file",
+        lambda: order.append("save"),
+    )
+    monkeypatch.setattr(bench, "_cleanup_logger_cache", lambda: order.append("cleanup"))
+    monkeypatch.setattr(
+        bench,
+        "_final_cleanup",
+        lambda: order.append("final_cleanup") or asyncio.sleep(0),
+    )
+
+    exit_code = asyncio.run(bench.run_benchmark())
+    assert exit_code == 0
+    assert "sync_logger" in bench.results
+    assert "memory" in bench.results
+    assert "async_logger" not in bench.results
+    assert "save" not in order

--- a/tests/extensions/test_extension_manager.py
+++ b/tests/extensions/test_extension_manager.py
@@ -134,3 +134,26 @@ def test_extension_manager_collects_metrics_only_from_extensions_with_method() -
     manager.add_extension("with_metrics", MetricsExtension(enabled=True))
     manager.add_extension("without_metrics", PrefixExtension(enabled=True))
     assert manager.get_extension_metrics() == {"with_metrics": {"hits": 1}}
+
+
+def test_extension_manager_reenable_moves_extension_to_tail() -> None:
+    manager = ExtensionManager()
+    manager.register_extension_type("prefix", PrefixExtension)
+    manager.create_extension("a", "prefix", enabled=True)
+    manager.create_extension("b", "prefix", enabled=True)
+    assert manager.get_processing_order() == ["a", "b"]
+
+    manager.disable_extension("a")
+    manager.enable_extension("a")
+    assert manager.get_processing_order() == ["b", "a"]
+
+
+def test_extension_manager_set_processing_order_overrides_registration_order() -> None:
+    manager = ExtensionManager()
+    manager.register_extension_type("prefix", PrefixExtension)
+    manager.create_extension("a", "prefix", enabled=True)
+    manager.create_extension("b", "prefix", enabled=True)
+    manager.create_extension("c", "prefix", enabled=True)
+    manager.set_processing_order(["c", "a", "b"])
+    assert manager.process_data("x") == "prefix:prefix:prefix:x"
+    assert manager.get_processing_order() == ["c", "a", "b"]

--- a/tests/loggers/test_async_logger.py
+++ b/tests/loggers/test_async_logger.py
@@ -592,6 +592,179 @@ def test_async_logger_setup_data_protection_uses_configured_patterns(
     logger.close()
 
 
+def test_async_logger_setup_data_protection_uses_first_security_extension_from_manager() -> (
+    None
+):
+    from hydra_logger.extensions.extension_base import SecurityExtension
+    from hydra_logger.extensions.extension_manager import ExtensionManager
+
+    logger = AsyncLogger()
+    logger._enable_data_protection = True
+    manager = ExtensionManager()
+    sec = SecurityExtension(enabled=True, patterns=["token"])
+    manager.add_extension("security_custom", sec)
+    logger._config = LoggingConfig()  # type: ignore[assignment]
+    setattr(logger._config, "_extension_manager", manager)  # type: ignore[arg-type]
+    logger._setup_data_protection()
+    assert logger._data_protection is sec
+    logger.close()
+
+
+def test_async_logger_data_protection_failure_respects_reliability_modes() -> None:
+    strict_logger = AsyncLogger(
+        config={
+            "strict_reliability_mode": True,
+            "enable_data_protection": True,
+            "layers": {"default": {"destinations": [{"type": "null"}]}},
+        }
+    )
+    assert strict_logger._data_protection is not None
+    strict_logger._data_protection.process = lambda _payload: (_ for _ in ()).throw(  # type: ignore[assignment]
+        RuntimeError("dp-fail")
+    )
+
+    original_get_running_loop = asyncio.get_running_loop
+    asyncio.get_running_loop = lambda: (_ for _ in ()).throw(RuntimeError("no-loop"))  # type: ignore[assignment]
+    try:
+        with pytest.raises(HydraLoggerError, match="internal failure"):
+            strict_logger.log("INFO", "token=abc")
+    finally:
+        asyncio.get_running_loop = original_get_running_loop  # type: ignore[assignment]
+    strict_logger.close()
+
+    async def _run_warn() -> None:
+        warn_logger = AsyncLogger(
+            config={
+                "reliability_error_policy": "warn",
+                "enable_data_protection": True,
+                "layers": {"default": {"destinations": [{"type": "null"}]}},
+            }
+        )
+        assert warn_logger._data_protection is not None
+        warn_logger._data_protection.process = lambda _payload: (_ for _ in ()).throw(  # type: ignore[assignment]
+            RuntimeError("dp-fail")
+        )
+        await warn_logger.log_async("INFO", "token=abc")
+        assert warn_logger.get_health_status()["swallowed_error_count"] >= 1
+        await warn_logger.aclose()
+
+    asyncio.run(_run_warn())
+
+
+def test_async_logger_close_and_aclose_hydraerror_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = AsyncLogger()
+
+    class BadClear:
+        def clear(self) -> None:
+            raise RuntimeError("clear-fail")
+
+    monkeypatch.setattr(
+        logger,
+        "_report_lifecycle_failure",
+        lambda _ctx, _err: (_ for _ in ()).throw(HydraLoggerError("close-policy")),
+    )
+    logger._handler_cache = BadClear()  # type: ignore[assignment]
+    with pytest.raises(HydraLoggerError, match="close-policy"):
+        logger.close()
+
+    async def _run() -> None:
+        logger2 = AsyncLogger()
+
+        class BadTask:
+            @staticmethod
+            def done() -> bool:
+                return False
+
+            @staticmethod
+            def cancel() -> None:
+                return None
+
+            def __await__(self):
+                raise RuntimeError("join-fail")
+                yield
+
+        logger2._overflow_worker_task = BadTask()  # type: ignore[assignment]
+        contexts = []
+        monkeypatch.setattr(
+            logger2,
+            "_report_lifecycle_failure",
+            lambda ctx, _err: contexts.append(ctx),
+        )
+        await logger2.aclose()
+        assert "overflow_worker_join" in contexts
+
+        logger3 = AsyncLogger()
+        logger3._handler_cache = BadClear()  # type: ignore[assignment]
+        monkeypatch.setattr(
+            logger3,
+            "_report_lifecycle_failure",
+            lambda _ctx, _err: (_ for _ in ()).throw(HydraLoggerError("aclose-policy")),
+        )
+        with pytest.raises(HydraLoggerError, match="aclose-policy"):
+            await logger3.aclose()
+
+    asyncio.run(_run())
+
+
+def test_async_logger_close_direct_hydraerror_branch() -> None:
+    logger = AsyncLogger()
+
+    class BadTask:
+        @staticmethod
+        def done() -> bool:
+            return False
+
+        @staticmethod
+        def cancel() -> None:
+            raise HydraLoggerError("cancel-hydra")
+
+    logger._overflow_worker_task = BadTask()  # type: ignore[assignment]
+    with pytest.raises(HydraLoggerError, match="cancel-hydra"):
+        logger.close()
+
+
+def test_async_logger_executes_non_data_extensions_in_deterministic_order() -> None:
+    from hydra_logger.extensions.extension_base import ExtensionBase, SecurityExtension
+    from hydra_logger.extensions.extension_manager import ExtensionManager
+
+    class SuffixExtension(ExtensionBase):
+        def process(self, data):  # type: ignore[no-untyped-def]
+            if isinstance(data, str):
+                return f"{data}{self.get_config().get('suffix', '')}"
+            return data
+
+    async def _run() -> None:
+        logger = AsyncLogger(
+            config={
+                "enable_data_protection": True,
+                "layers": {"default": {"destinations": [{"type": "null"}]}},
+            }
+        )
+        manager = ExtensionManager()
+        manager.register_extension_type("suffix", SuffixExtension)
+        manager.create_extension("append_a", "suffix", enabled=True, suffix=":A")
+        manager.create_extension("append_b", "suffix", enabled=True, suffix=":B")
+        manager.add_extension(
+            "data_protection",
+            SecurityExtension(enabled=True, patterns=["token"]),
+        )
+        manager.set_processing_order(["append_a", "data_protection", "append_b"])
+
+        logger._extension_manager = manager
+        logger._data_protection = manager.get_extension("data_protection")
+        captured = {}
+
+        async def _capture(record):  # type: ignore[no-untyped-def]
+            captured["message"] = record.message
+
+        logger._emit_to_handlers = _capture  # type: ignore[method-assign]
+        await logger.log_async("INFO", "token=abc")
+        assert captured["message"] == 'token="[REDACTED]":A:B'
+        await logger.aclose()
+
+    asyncio.run(_run())
+
+
 def test_async_logger_ensure_concurrency_semaphore_starts_worker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/loggers/test_async_logger.py
+++ b/tests/loggers/test_async_logger.py
@@ -651,7 +651,9 @@ def test_async_logger_data_protection_failure_respects_reliability_modes() -> No
     asyncio.run(_run_warn())
 
 
-def test_async_logger_close_and_aclose_hydraerror_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_async_logger_close_and_aclose_hydraerror_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     logger = AsyncLogger()
 
     class BadClear:

--- a/tests/loggers/test_composite_logger.py
+++ b/tests/loggers/test_composite_logger.py
@@ -201,6 +201,172 @@ def test_composite_async_logger_health_for_empty_components() -> None:
     logger.close()
 
 
+def test_composite_logger_lifecycle_hydraerror_and_health_last_error_paths() -> None:
+    logger = CompositeLogger(components=[])
+
+    class EmptyIterableWithFailingClear:
+        def __iter__(self):
+            return iter(())
+
+        @staticmethod
+        def clear() -> None:
+            raise RuntimeError("clear-fail")
+
+    logger.components = EmptyIterableWithFailingClear()  # type: ignore[assignment]
+    logger._report_lifecycle_failure = lambda _ctx, _err: (_ for _ in ()).throw(  # type: ignore[assignment]
+        HydraLoggerError("close-policy")
+    )
+    with pytest.raises(HydraLoggerError, match="close-policy"):
+        logger.close()
+    assert logger._closed is True
+
+    logger2 = CompositeLogger(components=[])
+    logger2._last_lifecycle_error = "sync-last-error"
+    health = logger2.get_health_status()
+    assert health["last_lifecycle_error"] == "sync-last-error"
+
+
+def test_composite_async_lifecycle_hydraerror_and_health_last_error_paths() -> None:
+    class EmptyIterableWithFailingClear:
+        def __iter__(self):
+            return iter(())
+
+        @staticmethod
+        def clear() -> None:
+            raise RuntimeError("clear-fail")
+
+    async def _run() -> None:
+        logger = CompositeAsyncLogger(components=[], use_direct_io=False)
+        logger.components = EmptyIterableWithFailingClear()  # type: ignore[assignment]
+        logger._report_async_lifecycle_failure = lambda _ctx, _err: (_ for _ in ()).throw(  # type: ignore[assignment]
+            HydraLoggerError("async-close-policy")
+        )
+        with pytest.raises(HydraLoggerError, match="async-close-policy"):
+            await logger._async_close()
+
+        logger2 = CompositeAsyncLogger(components=[], use_direct_io=False)
+        logger2.components = EmptyIterableWithFailingClear()  # type: ignore[assignment]
+        logger2._report_async_lifecycle_failure = lambda _ctx, _err: (_ for _ in ()).throw(  # type: ignore[assignment]
+            HydraLoggerError("sync-close-policy")
+        )
+        with pytest.raises(HydraLoggerError, match="sync-close-policy"):
+            logger2.close()
+
+        class HealthyComponent:
+            name = "healthy"
+
+            @staticmethod
+            def get_health_status():
+                return {"health": "healthy"}
+
+        logger3 = CompositeAsyncLogger(
+            components=[HealthyComponent()], use_direct_io=False
+        )  # type: ignore[list-item]
+        logger3._last_lifecycle_error = "async-last-error"
+        health = logger3.get_health_status()
+        assert health["last_lifecycle_error"] == "async-last-error"
+        await logger3.aclose()
+
+    asyncio.run(_run())
+
+
+def test_composite_logger_health_payload_includes_last_lifecycle_error_with_components() -> (
+    None
+):
+    class HealthyComponent:
+        name = "healthy"
+
+        @staticmethod
+        def get_health_status():
+            return {"health": "healthy"}
+
+    logger = CompositeLogger(components=[HealthyComponent()])  # type: ignore[list-item]
+    logger._last_lifecycle_error = "sync-health-last-error"
+    health = logger.get_health_status()
+    assert health["last_lifecycle_error"] == "sync-health-last-error"
+    logger.close()
+
+
+def test_composite_logger_outer_hydra_close_branch_sets_closed() -> None:
+    class RaiseOnClose:
+        name = "raise-close"
+
+        @staticmethod
+        def close() -> None:
+            raise RuntimeError("close-fail")
+
+    logger = CompositeLogger(components=[RaiseOnClose()])  # type: ignore[list-item]
+    logger._report_lifecycle_failure = lambda _ctx, _err: (_ for _ in ()).throw(  # type: ignore[assignment]
+        HydraLoggerError("outer-close-policy")
+    )
+    with pytest.raises(HydraLoggerError, match="outer-close-policy"):
+        logger.close()
+    assert logger._closed is True
+
+
+def test_composite_async_close_return_and_outer_error_branches() -> None:
+    class EmptyIterableWithFailingClear:
+        def __iter__(self):
+            return iter(())
+
+        @staticmethod
+        def clear() -> None:
+            raise RuntimeError("clear-fail")
+
+    async def _run_async_close_return_branch() -> None:
+        logger = CompositeAsyncLogger(components=[], use_direct_io=False)
+        logger.components = EmptyIterableWithFailingClear()  # type: ignore[assignment]
+        seen = []
+        logger._report_async_lifecycle_failure = lambda ctx, _err: seen.append(ctx)  # type: ignore[assignment]
+        await logger._async_close()
+        assert "async_composite_clear" in seen
+
+    asyncio.run(_run_async_close_return_branch())
+
+    class BadIterable:
+        def __iter__(self):
+            raise RuntimeError("iter-fail")
+
+        @staticmethod
+        def clear() -> None:
+            return None
+
+    async def _run_async_close_outer_branch() -> None:
+        logger = CompositeAsyncLogger(components=[], use_direct_io=False)
+        logger.components = BadIterable()  # type: ignore[assignment]
+        logger._report_async_lifecycle_failure = lambda _ctx, _err: (_ for _ in ()).throw(  # type: ignore[assignment]
+            HydraLoggerError("async-outer-policy")
+        )
+        with pytest.raises(HydraLoggerError, match="async-outer-policy"):
+            await logger._async_close()
+
+    asyncio.run(_run_async_close_outer_branch())
+
+    logger_sync_return = CompositeAsyncLogger(components=[], use_direct_io=False)
+    logger_sync_return.components = EmptyIterableWithFailingClear()  # type: ignore[assignment]
+    seen_sync = []
+    logger_sync_return._report_async_lifecycle_failure = lambda ctx, _err: seen_sync.append(ctx)  # type: ignore[assignment]
+    logger_sync_return.close()
+    assert "composite_async_sync_close_cleanup" in seen_sync
+
+    logger_sync_outer = CompositeAsyncLogger(components=[], use_direct_io=False)
+    logger_sync_outer.components = BadIterable()  # type: ignore[assignment]
+    logger_sync_outer._report_async_lifecycle_failure = lambda _ctx, _err: (_ for _ in ()).throw(  # type: ignore[assignment]
+        HydraLoggerError("sync-outer-policy")
+    )
+    with pytest.raises(HydraLoggerError, match="sync-outer-policy"):
+        logger_sync_outer.close()
+
+
+def test_composite_async_health_empty_payload_includes_last_error() -> None:
+    logger = CompositeAsyncLogger(components=[], use_direct_io=False)
+    logger.components = []
+    logger._last_lifecycle_error = "empty-health-last-error"
+    health = logger.get_health_status()
+    assert health["last_lifecycle_error"] == "empty-health-last-error"
+    logger.close()
+
+
 def test_composite_async_logger_flush_direct_io_clears_buffer_on_write_failure(
     monkeypatch,
 ) -> None:

--- a/tests/loggers/test_pipeline_components.py
+++ b/tests/loggers/test_pipeline_components.py
@@ -14,6 +14,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from hydra_logger.core.exceptions import HydraLoggerError
+from hydra_logger.extensions.extension_base import ExtensionBase, SecurityExtension
+from hydra_logger.extensions.extension_manager import ExtensionManager
 from hydra_logger.loggers.pipeline import (
     ComponentDispatcher,
     ExtensionProcessor,
@@ -112,6 +115,17 @@ class DummyDataProtection:
         if self._should_fail:
             raise RuntimeError("process failed")
         return f"masked:{message}"
+
+
+class FailingOwner:
+    def __init__(self, raise_hydra_error: bool = False) -> None:
+        self.raise_hydra_error = raise_hydra_error
+        self.calls = []
+
+    def _handle_internal_failure(self, context: str, error: Exception) -> None:
+        self.calls.append((context, str(error)))
+        if self.raise_hydra_error:
+            raise HydraLoggerError("strict failure")
 
 
 class SyncComponent:
@@ -324,6 +338,103 @@ def test_extension_processor_applies_data_protection_to_context_and_extra() -> N
     assert 'token="[REDACTED]"' in updated.message
     assert updated.context["auth"]["detail"] == 'token="[REDACTED]"'
     assert updated.extra["password"] == 'token="[REDACTED]"'
+
+
+def test_extension_processor_owner_handles_data_protection_failure_context() -> None:
+    owner = FailingOwner()
+    processor = ExtensionProcessor(owner)
+    record = SimpleNamespace(message="secret")
+    protection = DummyDataProtection(enabled=True, should_fail=True)
+
+    updated = processor.apply_data_protection(record, protection)
+    assert updated.message == "secret"
+    assert owner.calls == [("extension_data_protection", "process failed")]
+
+
+def test_extension_processor_reraises_hydra_error_from_owner() -> None:
+    owner = FailingOwner(raise_hydra_error=True)
+    processor = ExtensionProcessor(owner)
+    record = SimpleNamespace(message="secret")
+    protection = DummyDataProtection(enabled=True, should_fail=True)
+
+    with pytest.raises(HydraLoggerError, match="strict failure"):
+        processor.apply_data_protection(record, protection)
+
+
+def test_extension_processor_applies_non_data_extensions_in_order() -> None:
+    class SuffixExtension(ExtensionBase):
+        def process(self, data):  # type: ignore[no-untyped-def]
+            if isinstance(data, str):
+                return f"{data}{self.get_config().get('suffix', '')}"
+            return data
+
+    manager = ExtensionManager()
+    manager.register_extension_type("suffix", SuffixExtension)
+    manager.create_extension("append_a", "suffix", enabled=True, suffix=":A")
+    manager.create_extension("append_b", "suffix", enabled=True, suffix=":B")
+    manager.add_extension(
+        "data_protection",
+        SecurityExtension(enabled=True, patterns=["token"]),
+    )
+    manager.set_processing_order(["append_a", "data_protection", "append_b"])
+
+    processor = ExtensionProcessor()
+    record = SimpleNamespace(
+        message='token="abc"',
+        context={"message": 'token="abc"'},
+        extra={"note": "x"},
+    )
+    updated = processor.apply_non_data_protection_extensions(
+        record,
+        manager,
+        manager.get_extension("data_protection"),
+    )
+    assert updated.message == 'token="abc":A:B'
+    assert updated.context["message"] == 'token="abc"'
+
+
+def test_extension_processor_non_data_extension_failure_uses_owner_policy() -> None:
+    class FailingExtension(ExtensionBase):
+        def process(self, _data):  # type: ignore[no-untyped-def]
+            raise RuntimeError("ext-fail")
+
+    owner = FailingOwner(raise_hydra_error=True)
+    manager = ExtensionManager()
+    manager.register_extension_type("failing", FailingExtension)
+    manager.create_extension("boom", "failing", enabled=True)
+    processor = ExtensionProcessor(owner)
+    record = SimpleNamespace(message="x", context=None, extra=None)
+
+    with pytest.raises(HydraLoggerError, match="strict failure"):
+        processor.apply_non_data_protection_extensions(record, manager, None)
+
+
+def test_extension_processor_non_data_extensions_skip_disabled_and_log_ownerless_failures(
+    caplog,
+) -> None:
+    class DisabledExtension(ExtensionBase):
+        def process(self, data):  # type: ignore[no-untyped-def]
+            return f"disabled:{data}"
+
+    class FailingExtension(ExtensionBase):
+        def process(self, _data):  # type: ignore[no-untyped-def]
+            raise RuntimeError("no-owner-fail")
+
+    manager = ExtensionManager()
+    manager.register_extension_type("disabled_ext", DisabledExtension)
+    manager.register_extension_type("failing_ext", FailingExtension)
+    manager.create_extension("disabled_one", "disabled_ext", enabled=False)
+    manager.create_extension("failing_one", "failing_ext", enabled=True)
+    manager.set_processing_order(["disabled_one", "failing_one"])
+
+    processor = ExtensionProcessor()
+    record = SimpleNamespace(message="x", context=None, extra=None)
+    with caplog.at_level(
+        "ERROR", logger="hydra_logger.loggers.pipeline.extension_processor"
+    ):
+        updated = processor.apply_non_data_protection_extensions(record, manager, None)
+    assert updated.message == "x"
+    assert "Extension processing failed for extension=failing_one" in caplog.text
 
 
 def test_component_dispatcher_sync_fanout_tolerates_component_failure() -> None:

--- a/tests/loggers/test_sync_logger.py
+++ b/tests/loggers/test_sync_logger.py
@@ -603,6 +603,84 @@ def test_sync_logger_data_protection_import_error_branch(
     logger.close()
 
 
+def test_sync_logger_data_protection_failure_respects_reliability_modes() -> None:
+    strict_logger = SyncLogger(
+        config={
+            "strict_reliability_mode": True,
+            "enable_data_protection": True,
+            "layers": {
+                "default": {
+                    "destinations": [{"type": "console", "format": "plain-text"}]
+                }
+            },
+        }
+    )
+    assert strict_logger._data_protection is not None
+    strict_logger._data_protection.process = lambda _payload: (_ for _ in ()).throw(  # type: ignore[assignment]
+        RuntimeError("dp-fail")
+    )
+    with pytest.raises(HydraLoggerError, match="internal failure"):
+        strict_logger.log("INFO", "token=abc")
+    strict_logger.close()
+
+    warn_logger = SyncLogger(
+        config={
+            "reliability_error_policy": "warn",
+            "enable_data_protection": True,
+            "layers": {
+                "default": {
+                    "destinations": [{"type": "console", "format": "plain-text"}]
+                }
+            },
+        }
+    )
+    assert warn_logger._data_protection is not None
+    warn_logger._data_protection.process = lambda _payload: (_ for _ in ()).throw(  # type: ignore[assignment]
+        RuntimeError("dp-fail")
+    )
+    warn_logger.log("INFO", "token=abc")
+    assert warn_logger.get_health_status()["swallowed_error_count"] >= 1
+    warn_logger.close()
+
+
+def test_sync_logger_executes_non_data_extensions_in_deterministic_order() -> None:
+    from hydra_logger.extensions.extension_base import ExtensionBase, SecurityExtension
+    from hydra_logger.extensions.extension_manager import ExtensionManager
+
+    class SuffixExtension(ExtensionBase):
+        def process(self, data):  # type: ignore[no-untyped-def]
+            if isinstance(data, str):
+                return f"{data}{self.get_config().get('suffix', '')}"
+            return data
+
+    logger = SyncLogger(
+        config={
+            "enable_data_protection": True,
+            "layers": {"default": {"destinations": [{"type": "null"}]}},
+        }
+    )
+    manager = ExtensionManager()
+    manager.register_extension_type("suffix", SuffixExtension)
+    manager.create_extension("append_a", "suffix", enabled=True, suffix=":A")
+    manager.create_extension("append_b", "suffix", enabled=True, suffix=":B")
+    manager.add_extension(
+        "data_protection",
+        SecurityExtension(enabled=True, patterns=["token"]),
+    )
+    manager.set_processing_order(["append_a", "data_protection", "append_b"])
+
+    logger._extension_manager = manager
+    logger._data_protection = manager.get_extension("data_protection")
+    captured = {}
+    logger._handler_dispatcher.dispatch_sync = (
+        lambda rec, _handlers: captured.setdefault("message", rec.message)
+    )  # type: ignore[method-assign]
+
+    logger.log("INFO", "token=abc")
+    assert captured["message"] == 'token="[REDACTED]":A:B'
+    logger.close()
+
+
 def test_sync_logger_internal_failure_warn_policy_logs_warning(caplog) -> None:
     logger = SyncLogger(
         config={
@@ -618,3 +696,21 @@ def test_sync_logger_internal_failure_warn_policy_logs_warning(caplog) -> None:
         logger._handle_internal_failure("unit-test", RuntimeError("boom"))
     assert "Sync logger failure [unit-test]" in caplog.text
     logger.close()
+
+
+def test_sync_logger_close_cleanup_hydraerror_branch() -> None:
+    logger = SyncLogger()
+
+    class BadDict(dict):
+        def clear(self) -> None:
+            raise RuntimeError("clear-fail")
+
+    logger._handlers = BadDict()  # type: ignore[assignment]
+    logger._layer_handlers = BadDict()  # type: ignore[assignment]
+    logger._layers = BadDict()  # type: ignore[assignment]
+    logger._report_lifecycle_failure = lambda _ctx, _err: (_ for _ in ()).throw(  # type: ignore[assignment]
+        HydraLoggerError("close-policy")
+    )
+    with pytest.raises(HydraLoggerError, match="close-policy"):
+        logger.close()
+    assert logger._closed is True

--- a/tests/utils/test_reliability_lifecycle.py
+++ b/tests/utils/test_reliability_lifecycle.py
@@ -1,0 +1,56 @@
+"""
+Role: Tests for lifecycle reliability policy helper.
+Used By:
+ - Pytest discovery and CI policy regression checks.
+Depends On:
+ - hydra_logger
+Notes:
+ - Validates raise/warn behavior and failure counter handling.
+"""
+
+import pytest
+
+from hydra_logger.core.exceptions import HydraLoggerError
+from hydra_logger.utils import reliability_lifecycle
+
+
+def test_handle_lifecycle_failure_warn_and_raise_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = {"count": 0, "last": ""}
+    warnings = []
+
+    monkeypatch.setattr(
+        "hydra_logger.utils.reliability_lifecycle.diagnostics.warning",
+        lambda msg, detail: warnings.append(msg % detail),
+    )
+
+    def _inc() -> None:
+        state["count"] += 1
+
+    reliability_lifecycle.handle_lifecycle_failure(
+        context="close",
+        error=RuntimeError("boom"),
+        logger_name="unit",
+        strict_reliability_mode=False,
+        reliability_error_policy="warn",
+        failure_warning_interval=1,
+        increment_close_failures=_inc,
+        get_close_failure_count=lambda: state["count"],
+        set_last_error=lambda text: state.__setitem__("last", text),
+    )
+    assert warnings and "lifecycle failure [close]" in warnings[0]
+    assert "lifecycle failure [close]" in state["last"]
+
+    with pytest.raises(HydraLoggerError, match="lifecycle failure"):
+        reliability_lifecycle.handle_lifecycle_failure(
+            context="close",
+            error=RuntimeError("boom"),
+            logger_name="unit",
+            strict_reliability_mode=True,
+            reliability_error_policy="silent",
+            failure_warning_interval=100,
+            increment_close_failures=_inc,
+            get_close_failure_count=lambda: state["count"],
+            set_last_error=lambda text: state.__setitem__("last", text),
+        )


### PR DESCRIPTION
## Summary
- Add strict failure-path extension processing tests and owner policy propagation.
- Execute non-data-protection extensions in deterministic runtime order after data protection.
- Add benchmark section filtering (enabled_sections/--sections) with safe partial-run persistence behavior.

## Test plan
- [ ] Add verification commands before merge

## Attribution
- Author: Savin I. Razvan
- GitHub-User: @SavinRazvan
- Agent/s: review-pr | prepare-pr | merge-pr
- Made-with: Cursor
