### PR TITLE
fix(packaging): restore MIT license classifier and static README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/SavinRazvan/hydra-logger/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/SavinRazvan/hydra-logger/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-3776AB?logo=python&logoColor=white)](https://github.com/SavinRazvan/hydra-logger/blob/main/setup.py)
 [![Coverage](https://codecov.io/gh/SavinRazvan/hydra-logger/branch/main/graph/badge.svg)](https://codecov.io/gh/SavinRazvan/hydra-logger)
-[![License](https://img.shields.io/github/license/SavinRazvan/hydra-logger)](https://github.com/SavinRazvan/hydra-logger/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SavinRazvan/hydra-logger/blob/main/LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/hydra-logger?color=blue)](https://pypi.org/project/hydra-logger/)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/hydra-logger?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=MAGENTA&left_text=downloads)](https://pepy.tech/projects/hydra-logger)
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/tests/packaging/test_setup_classifiers_contract.py
+++ b/tests/packaging/test_setup_classifiers_contract.py
@@ -50,3 +50,9 @@ def test_development_status_singleton() -> None:
     assert (
         len(dev_status) == 1
     ), f"expected one Development Status classifier, got {dev_status!r}"
+
+
+def test_mit_license_classifier_present() -> None:
+    root = Path(__file__).resolve().parents[2]
+    classifiers = _classifier_list(root / "setup.py")
+    assert "License :: OSI Approved :: MIT License" in classifiers


### PR DESCRIPTION
## Summary
- Re-add OSI MIT PyPI classifier for verified license metadata
- Switch README license badge to static shields.io MIT badge

## Test plan
- [ ] Add verification commands before merge

## Attribution
- Author: Savin I. Razvan
- GitHub-User: @SavinRazvan
- Agent/s: review-pr | prepare-pr | merge-pr
- Made-with: Cursor
